### PR TITLE
Add colon to safe characters in SAS token

### DIFF
--- a/azure-storage-blob/azure/storage/blob/sharedaccesssignature.py
+++ b/azure-storage-blob/azure/storage/blob/sharedaccesssignature.py
@@ -271,5 +271,5 @@ class _BlobSharedAccessHelper(_SharedAccessHelper):
         # a conscious decision was made to exclude the timestamp in the generated token
         # this is to avoid having two snapshot ids in the query parameters when the user appends the snapshot timestamp
         exclude = [_BlobQueryStringConstants.SIGNED_TIMESTAMP]
-        return '&'.join(['{0}={1}'.format(n, url_quote(v))
+        return '&'.join(['{0}={1}'.format(n, url_quote(v, safe="/:"))
                          for n, v in self.query_dict.items() if v is not None and n not in exclude])


### PR DESCRIPTION
This matches the output from generating a SAS token using Azure portal.